### PR TITLE
fix that wrong command was used when mixed DNS servers were being set

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -193,16 +193,17 @@ pub(crate) fn set_interface_dns_servers_via_cmd(adapter: &str, dns: &[IpAddr]) -
     if dns.is_empty() {
         return Ok(());
     }
-    let ip_str = if dns[0].is_ipv4() { "ipv4" } else { "ipv6" };
 
     // netsh interface ipv4 set dns name="MyAdapter" source="static" address="8.8.8.8"
     // netsh interface ipv4 add dns name="MyAdapter" index=2 address="8.8.4.4"
+    let ip_str = if dns[0].is_ipv4() { "ipv4" } else { "ipv6" };
     let name = format!("name=\"{}\"", adapter);
     let addr = format!("address=\"{}\"", dns[0]);
     let args = vec!["interface", ip_str, "set", "dns", &name, "source=\"static\"", &addr];
     run_command("netsh", &args)?;
     let mut index = 2;
     for dns in dns.iter().skip(1) {
+        let ip_str = if dns.is_ipv4() { "ipv4" } else { "ipv6" };
         let addr = format!("address=\"{}\"", dns);
         let idx = format!("index={}", index);
         let args = vec!["interface", ip_str, "add", "dns", &name, &idx, &addr];


### PR DESCRIPTION
Because of how setting DNS servers works, the loop had to be unrolled, but the same `ip_str` argument was erroneously used for all iterations.